### PR TITLE
Migration from PEP8 to pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
     - 3.6
 before_install:
-    - pip3 install pep8
+    - pip3 install pycodestyle
     
 script:
     # Run pep8 on all .py files in all subfolders
     # (I ignore "E402: module level import not at top of file"
     # because of use case sys.path.append('..'); import <module>)
-    - find . -name \*.py -exec pep8 --ignore=E402 {} +
+    - find . -name \*.py -exec pycodestyle --ignore=E402 {} +


### PR DESCRIPTION
Regarding this warning:

> pep8 has been renamed to pycodestyle (GitHub issue #466)
> Use of the pep8 tool will be removed in a future release.
> Please install and use `pycodestyle` instead.``)

we need to replace pep8 in `.travis.yml` with pycodestyle.